### PR TITLE
(feature)message-list: 本文表示切替機能追加

### DIFF
--- a/src/app/user-shell/message-list/message-card/message-card.component.html
+++ b/src/app/user-shell/message-list/message-card/message-card.component.html
@@ -1,6 +1,6 @@
 <div class="message-card">
   <h2 class="message-card__title">{{ user.title }}</h2>
-  <div class="message-card__content">
+  <div class="message-card__content" *ngIf="isOpen" [@slideInOut]>
     {{ user.message }}
   </div>
   <div class="message-card__footer">

--- a/src/app/user-shell/message-list/message-card/message-card.component.scss
+++ b/src/app/user-shell/message-list/message-card/message-card.component.scss
@@ -18,17 +18,18 @@
   }
   &__title {
     font-size: 18px;
+    margin-bottom: 20px;
   }
   &__content {
-    flex: 1;
     margin: 0;
-    padding: 20px 0;
     color: map-get($mat-grey, 800);
     font-size: 14px;
     text-align: justify;
     white-space: pre-wrap;
   }
   &__footer {
+    margin-top: auto;
+    padding-top: 20px;
     display: flex;
   }
   &__data {

--- a/src/app/user-shell/message-list/message-card/message-card.component.ts
+++ b/src/app/user-shell/message-list/message-card/message-card.component.ts
@@ -1,3 +1,4 @@
+import { animate, style, transition, trigger } from '@angular/animations';
 import { Component, Input, OnInit } from '@angular/core';
 import { UserData } from 'src/app/interfaces/user-data';
 import { AuthService } from 'src/app/services/auth.service';
@@ -6,9 +7,36 @@ import { AuthService } from 'src/app/services/auth.service';
   selector: 'app-message-card',
   templateUrl: './message-card.component.html',
   styleUrls: ['./message-card.component.scss'],
+  animations: [
+    trigger('slideInOut', [
+      transition(':enter', [
+        style({
+          height: '0',
+          opacity: 0,
+        }),
+        animate(
+          '200ms ease',
+          style({
+            height: '*',
+            opacity: 1,
+          })
+        ),
+      ]),
+      transition(':leave', [
+        animate(
+          '200ms ease',
+          style({
+            height: '0',
+            opacity: 0,
+          })
+        ),
+      ]),
+    ]),
+  ],
 })
 export class MessageCardComponent implements OnInit {
   @Input() user: UserData;
+  @Input() isOpen: boolean;
 
   constructor(public authService: AuthService) {}
 

--- a/src/app/user-shell/message-list/message-list.module.ts
+++ b/src/app/user-shell/message-list/message-list.module.ts
@@ -1,6 +1,8 @@
 import { NgModule } from '@angular/core';
 import { CommonModule } from '@angular/common';
 
+import { FormsModule } from '@angular/forms';
+
 import { MessageListRoutingModule } from './message-list-routing.module';
 import { MessageListComponent } from './message-list/message-list.component';
 import { MessageCardComponent } from './message-card/message-card.component';
@@ -9,16 +11,19 @@ import { MatCardModule } from '@angular/material/card';
 import { MatIconModule } from '@angular/material/icon';
 import { MatButtonModule } from '@angular/material/button';
 import { MatProgressSpinnerModule } from '@angular/material/progress-spinner';
+import { MatSlideToggleModule } from '@angular/material/slide-toggle';
 
 @NgModule({
   declarations: [MessageListComponent, MessageCardComponent],
   imports: [
     CommonModule,
     MessageListRoutingModule,
+    FormsModule,
     MatCardModule,
     MatIconModule,
     MatButtonModule,
     MatProgressSpinnerModule,
+    MatSlideToggleModule,
   ],
 })
 export class MessageListModule {}

--- a/src/app/user-shell/message-list/message-list/message-list.component.html
+++ b/src/app/user-shell/message-list/message-list/message-list.component.html
@@ -3,11 +3,14 @@
     <div class="loading-wrapper" *ngIf="isloading">
       <mat-spinner class="loading" diameter="56" color="accent"></mat-spinner>
     </div>
-
+    <div class="message-list__toggle" *ngIf="!isloading">
+      <mat-slide-toggle [(ngModel)]="isOpen">本文表示</mat-slide-toggle>
+    </div>
     <div class="message-list__inner">
       <app-message-card
         *ngFor="let user of users$ | async"
         [user]="user"
+        [isOpen]="isOpen"
       ></app-message-card>
     </div>
   </div>

--- a/src/app/user-shell/message-list/message-list/message-list.component.scss
+++ b/src/app/user-shell/message-list/message-list/message-list.component.scss
@@ -1,3 +1,4 @@
+@import '~@angular/material/theming';
 @import 'variables';
 @import 'mixins';
 
@@ -5,6 +6,21 @@
   padding: 40px 0;
   @include sp {
     padding: 30px 0;
+  }
+  &__toggle {
+    padding-bottom: 16px;
+    text-align: right;
+    color: map-get($mat-grey, 200);
+    @include sp {
+      position: fixed;
+      bottom: 0;
+      left: 0;
+      right: 0;
+      padding: 16px 16px;
+      background-color: rgba(107, 141, 214, 0.95);
+      text-align: center;
+      z-index: 99;
+    }
   }
   &__inner {
     display: grid;

--- a/src/app/user-shell/message-list/message-list/message-list.component.ts
+++ b/src/app/user-shell/message-list/message-list/message-list.component.ts
@@ -10,6 +10,7 @@ import { UserService } from 'src/app/services/user.service';
   styleUrls: ['./message-list.component.scss'],
 })
 export class MessageListComponent implements OnInit {
+  isOpen = true;
   isloading: boolean;
 
   users$: Observable<UserData[]> = this.userService

--- a/src/app/user-shell/user-shell/user-shell.component.scss
+++ b/src/app/user-shell/user-shell/user-shell.component.scss
@@ -5,6 +5,7 @@
   display: block;
   min-height: 100%;
   background: $gradient-admin-main;
+  background-attachment: fixed;
 }
 
 .wrap {


### PR DESCRIPTION
Fixes #72

お疲れ様です！
先日、井上さんがおっしゃってたメッセージ一覧の「続きを読む」実装について、
私もJS側で処理する場合とCSSで処理する場合、両方試して見たんですが、
しっくりくる結果になりませんでした😥

代替案として、全件の本文表示切替を実装してみたので、
これでもよやそうなら、マージをお願いします🙏

![Dear](https://user-images.githubusercontent.com/46749854/98127884-8e1f3800-1efa-11eb-8853-7b0147ef5a69.gif)
