### PR TITLE
スマホ時にログインリンクが隠れる不具合を解消

### DIFF
--- a/src/app/user-shell/user-footer/user-footer.component.scss
+++ b/src/app/user-shell/user-footer/user-footer.component.scss
@@ -11,6 +11,7 @@
     font-size: 14px;
     @include sp {
       display: block;
+      padding: 16px 0 72px;
     }
   }
   &__login {


### PR DESCRIPTION
fix #77 

スマホ時にログインリンクが隠れる不具合を解消しました。
どなたか、ご確認&マージよろしくお願いします。

![localhost_4200_message-list(iPhone 5_SE)](https://user-images.githubusercontent.com/46749854/99948655-19cf0a80-2dbd-11eb-82c7-6d14078a81b4.png)
