### PR TITLE
タイムライン: 他のメッセージを開いても折りたたまれないようにする

### DIFF
--- a/src/app/main-shell/home/time-line/time-line.component.html
+++ b/src/app/main-shell/home/time-line/time-line.component.html
@@ -24,7 +24,7 @@
     />
   </h2>
   <div class="container">
-    <mgl-timeline>
+    <mgl-timeline [toggle]="false">
       <mgl-timeline-entry *ngFor="let user of users$ | async as users">
         <mgl-timeline-entry-header
           ><img


### PR DESCRIPTION
fixes #82 
タイムラインでメッセージを開いた時に他のメッセージが折りたたまれないように変更しました。ご確認お願いいたします！
## イメージ
[![Image from Gyazo](https://i.gyazo.com/f3a81dc7510f50a3b46f6b6f86dd440f.gif)](https://gyazo.com/f3a81dc7510f50a3b46f6b6f86dd440f)